### PR TITLE
Fix S3-Trio driver and use it in prep/qemu

### DIFF
--- a/cpu/ppc/prep/qemu/fw.bth
+++ b/cpu/ppc/prep/qemu/fw.bth
@@ -22,7 +22,7 @@ fload ${BP}/forth/lib/sysuart.fth	\ Plug UART routines into key and emit
    ." Open Firmware"
    " build-date"  $find  if  ."  , Built  " execute type  else  2drop  then  cr
    ?spaces ." Copyright (c) 1995-2000, FirmWorks." cr
-   ?spaces ." Copyright (c) 2014, Artyom Tarasenko." cr
+   ?spaces ." Copyright (c) 2014,2017, Artyom Tarasenko." cr
 ;
 ' fw-title to .firmware
 

--- a/cpu/ppc/prep/qemu/rom.bth
+++ b/cpu/ppc/prep/qemu/rom.bth
@@ -8,6 +8,7 @@ in: ${BP}/cpu/ppc/prep/qemu/build/resetvec.di
 in: ${BP}/cpu/ppc/prep/qemu/build/fw.dic
 in: ${BP}/dev/video/build/bga.fc
 in: ${BP}/dev/video/build/cirrus.fc
+in: ${BP}/dev/video/build/video.fc
 build-now
 
 \needs $add-dropin  fload ${BP}/forth/lib/mkdropin.fth
@@ -24,7 +25,8 @@ writing qprepofw.rom
 
    " builton.fth"                          " probe-"       $add-dropin
    " ${BP}/dev/video/build/cirrus.fc"      " pci1013,b8"   $add-dropin
-   " ${BP}/dev/video/build/bga.fc"         " class030000"  $add-dropin
+   " ${BP}/dev/video/build/bga.fc"         " pci1234,1111" $add-dropin
+   " ${BP}/dev/video/build/video.fc"       " class030000"  $add-dropin
    " ${BP}/ofw/termemu/cp881-16.obf"       " font"         $add-dropin
 \ h# 8.0000 pad-file
 ofd @ fclose

--- a/dev/video/controlr/s3.fth
+++ b/dev/video/controlr/s3.fth
@@ -55,17 +55,21 @@ headerless
 
    s3-trio64? s3-virge? or  if
       4 c-l@ 2 or 4 c-l!
-      3cc io-base + cpeek  if  ff =  else  true  then  if  1 3c3 pc!  then
+      3cc io-base + cpeek  if ff =
+      \ Hercules Terminator with Trio-64V+ version 54 responds with
+      \ a9 here. The manual says 10 in bit 3-2 is a reserved combination,
+      \ but it might be an unreliable test. It looks like after the vga-wakeup
+      \ the 2f register is unlocked, so check the chip version there.
+      \ The former comment stated that '764 and '765 are indistinguishable
+      \ at this point, so it might be the case for the earlier chip versions.
+      \ Get back here if someone reports regression with Trio-64.
+      s3-trio64?  if 2f crt@ 40 and or then \ Trio-64V+
+      else  true  then  if  1 3c3 pc!  then
    then
 
-   \ As it turns out, the Trio-64V+ (which at this point in the probe process
-   \ is indistinguishable from all of the other versions of the Trio-64, also
-   \ won't have initialized prior to the above command. So, that extra command
-   \ is usefull for both the "Z" Trio-64 and the Trio-64V+ (also known as the
-   \ '765 [all other Trios have a '764 part number]). Oh but wait, there is 
-   \ more. The 765 does not respond to IO accesses unless the memory access 
-   \ enable bit is also turned on. Which is why the above now includes this 
-   \ "feature".
+   \ Oh but wait, there is  more. The 765 does not respond to IO accesses
+   \ unless the memory access  enable bit is also turned on. Which is why
+   \ the above now includes this  "feature".
 
    \ And now back to our regularly scheduled programming...
 

--- a/dev/video/controlr/s3.fth
+++ b/dev/video/controlr/s3.fth
@@ -290,6 +290,7 @@ headerless
    ['] s3-crt-table             to crt-table
    ['] init-s3-controller       to init-controller
    ['] reinit-s3-controller     to reinit-controller
+   ['] vga-video-on             to video-on
    use-s3-dac-methods
 ;
 

--- a/ofw/core/ofwcore.fth
+++ b/ofw/core/ofwcore.fth
@@ -1422,11 +1422,22 @@ action:  drop  ;
    then
 ;
 
-: delete-property  ( name-adr,len -- )
+: (delete-property)  ( name-adr,len -- )
    current-properties (search-wordlist)  if
       >link current-properties  remove-word
    then
 ;
+
+: delete-property  ( name-adr,len  -- )
+   my-self if
+      context token@ >r my-voc (select-package)
+      (delete-property)
+      r> context token!
+   else
+      (delete-property)
+   then
+;
+
 : forget  \ name  ( -- )
    current token@  device-node?  abort" Can't forget device methods"
    forget


### PR DESCRIPTION
qemu-system-ppc -M 40p  has by default S3 Trio video adapter.
While at it fix dev/video/controlr/s3.fth and add support for Hercules Terminator S3-Trio 64V+ card.