### PR TITLE
x86/Linux: fix creation of raw inflater image

### DIFF
--- a/cpu/x86/Linux/Makefile
+++ b/cpu/x86/Linux/Makefile
@@ -50,7 +50,7 @@ xinflate.o: xinflate.lo
 	${LD} -melf_i386 -T inflate.ld $< -o $@
 
 ../build/inflate.bin: xinflate.o
-	objcopy -O binary $< $@
+	objcopy -O binary -j text_inflate -j .text_spare $< $@
 
 %.o: ${WRDIR}/%.c
 	${CC} -c ${OPT} ${CFLAGS} $< -o $@


### PR DESCRIPTION
Copy only the sections we need -- various compiler versions add various extra sections. In particular, the .note.gnu.property section can precede .text, ruining the entry point.

Tested on Debian trixie with GCC 14.2.0 and Fedora 40 with:

  qemu-system-i386 -bios cpu/x86/pc/emu/build/emuofw.rom -serial stdio

This might be broken on other platforms too -- I didn't check.