### PR TITLE
mips: make sure we don't create GOT relocations

### DIFF
--- a/cpu/mips/Linux/makefile
+++ b/cpu/mips/Linux/makefile
@@ -24,7 +24,7 @@ wrapper.o: ${BP}/forth/wrapper/wrapper.c
 	${CC} ${CFLAGS} -c ${BP}/forth/wrapper/wrapper.c
 
 xinflate.lo: ${ZIPDIR}/inflate.c
-	${CC} -c ${CFLAGS} -mabi=32 -mfp32 -mips1 -EL -O $< -o $@
+	${CC} -c ${CFLAGS} -mno-shared -mabi=32 -mfp32 -mips1 -EL -O $< -o $@
 
 xinflate.o: xinflate.lo
 	${LD} -T inflate.ld -EL -G0 -N $< -o $@


### PR DESCRIPTION
Some toolchains fail to build the inflater:

```
  make[2]: Entering directory `openfirmware/cpu/mips/Linux'
  /opt/mips64-linux-musl-cross/bin/mips64-linux-musl-gcc -c -O -g -D__linux__ -DMIPS -DHOSTMIPS -mabi=32 -mfp32 -mips1 -EL -O ../../../forth/wrapper/zip/inflate.c -o xinflate.lo
  /opt/mips64-linux-musl-cross/bin/mips64-linux-musl-ld -T inflate.ld -EL -G0 -N xinflate.lo -o xinflate.o
  xinflate.lo: in function `inflate':
  ../../../forth/wrapper/zip/inflate.c:(text_inflate+0x3f0): relocation truncated to fit: R_MIPS_GOT16 against `.text'
  ../../../forth/wrapper/zip/inflate.c:(text_inflate+0x3fc): relocation truncated to fit: R_MIPS_GOT16 against `.text'
  ../../../forth/wrapper/zip/inflate.c:(text_inflate+0xed4): relocation truncated to fit: R_MIPS_GOT16 against `.text'
  make[2]: *** [xinflate.o] Error 1
  make[2]: Leaving directory `openfirmware/cpu/mips/Linux'
```