### PR TITLE
kernel/sysio: don't default to all-ones permissions

### DIFF
--- a/forth/kernel/sysio.fth
+++ b/forth/kernel/sysio.fth
@@ -69,7 +69,7 @@ decimal
 \ Defaults to public read permission, owner and group write permission.
 
 variable file-protection
--1 is file-protection  \ Use system default until overridden
+o# 666 is file-protection \ Use rw-rw-rw- until overridden
 
 \ Prepares a file for later access.  Name is the pathname of the file
 \ and mode is the mode (0 read, 1 write, 2 modify).  If the operation


### PR DESCRIPTION
The file-protection variable is understood to be an (unsigned) UNIX file mode everywhere, and contrary to what the comment says the -1 is not a default of any sort.

In fact, such a file mode is a pretty terrible thing, because the files end up being setuid executables. That is -- anyone could execute them with the privileges of whoever run the build. It's a matter of luck that umask typically chops off the writable bits and the images generated during the build are likely to just terminate upon an attempt to execute them.

This calls for wisdom: let's use what the UNIX programs typically use for mode bits, for it is the number of a regular non-executable file, and this number is 666, octal.

(Cherry picked from 8577d30955a0 in quozl/openfirmware/)